### PR TITLE
Update fastai

### DIFF
--- a/runtime/py-cpu.yml
+++ b/runtime/py-cpu.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - fastai=2.0.0=pyh39e3cac_0
+  - fastai=2.0.13=py_0
   - lightgbm=2.3.1=py38he1b5a44_0
   - mahotas=1.4.11=py38hc5bc63f_0
   - opencv=4.4.0=py38_2

--- a/runtime/py-gpu.yml
+++ b/runtime/py-gpu.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - fastai=2.0.0=pyh39e3cac_0
+  - fastai=2.0.13=py_0
   - lightgbm=2.3.1=py38he1b5a44_0
   - mahotas=1.4.11=py38hc5bc63f_0
   - opencv=4.4.0=py38_2


### PR DESCRIPTION
Please consider updating fastai to the latest build.  
The installed version 2.0.0 fails to import some modules when running my submission.