### PR TITLE
Remove more and just print all make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,5 +180,4 @@ help:
 			printf "%s ", words[i]; \
 		} \
 		printf "\n"; \
-	}' \
-	| more $(shell test $(shell uname) = Darwin && echo '--no-init --raw-control-chars')
+	}'


### PR DESCRIPTION
`more` is not available on windows bash, so we shouldn't rely on it

Should address at least part of #18 